### PR TITLE
修复了新版 vscode "terminal.integrated.shell.windows" 的默认属性为 powershell 的问题

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "Lua.diagnostics.globals": ["ac", "fs", "base", "war3"]
+    "Lua.diagnostics.globals": ["ac", "fs", "base", "war3"],
+    "terminal.integrated.shell.windows": "C:\\Windows\\System32\\cmd.exe"
 }


### PR DESCRIPTION
微不足道的小改动 ..
因为不熟悉 win 上的 vscode，被谋害掉了不少时间。